### PR TITLE
Resize font fix

### DIFF
--- a/Scoreboard/pages/scoreboard.html
+++ b/Scoreboard/pages/scoreboard.html
@@ -75,9 +75,9 @@
 
         function resizeFontEvent()
         {
-			var body = document.body;
-            var width = body.scrollWidth;
-            var height = body.scrollHeight;
+            var docElement = document.documentElement;
+            var width = docElement.scrollWidth;
+            var height = docElement.scrollHeight;
             var sizeRatio = width / height;
 
             if (sizeRatio > 1.4) {

--- a/Scoreboard/pages/scoreboard.html
+++ b/Scoreboard/pages/scoreboard.html
@@ -75,9 +75,9 @@
 
         function resizeFontEvent()
         {
-            var docElement = document.documentElement;
-            var width = docElement.scrollWidth;
-            var height = docElement.scrollHeight;
+            var scrollingElement = getScrollingElement();
+            var width = scrollingElement.scrollWidth;
+            var height = scrollingElement.scrollHeight;
             var sizeRatio = width / height;
 
             if (sizeRatio > 1.4) {

--- a/Scoreboard/pages/scoreboard.js
+++ b/Scoreboard/pages/scoreboard.js
@@ -105,6 +105,18 @@ function copyToClipboard(text) {
     }
 }
 
+function getScrollingElement() {
+    // From https://dev.opera.com/articles/fixing-the-scrolltop-bug/
+    if ('scrollingElement' in document) {
+        return document.scrollingElement;
+    }
+    // Fallback for legacy browsers
+    if (navigator.userAgent.indexOf('WebKit') != -1) {
+        return document.body;
+    }
+    return document.documentElement;
+}
+
 class DataSources
 {      
     constructor()

--- a/Scoreboard/pages/shot-clock.html
+++ b/Scoreboard/pages/shot-clock.html
@@ -42,9 +42,9 @@
 
         function resizeShotClockFont()
         {
-            var docElement = document.documentElement;
-            var width = docElement.scrollWidth;
-            var height = docElement.scrollHeight;
+            var scrollingElement = getScrollingElement();
+            var width = scrollingElement.scrollWidth;
+            var height = scrollingElement.scrollHeight;
             var sizeRatio = width / height;
 
             if (sizeRatio > 1.4) {

--- a/Scoreboard/pages/shot-clock.html
+++ b/Scoreboard/pages/shot-clock.html
@@ -42,9 +42,9 @@
 
         function resizeShotClockFont()
         {
-            var body = document.body;
-            var width = body.scrollWidth;
-            var height = body.scrollHeight;
+            var docElement = document.documentElement;
+            var width = docElement.scrollWidth;
+            var height = docElement.scrollHeight;
             var sizeRatio = width / height;
 
             if (sizeRatio > 1.4) {


### PR DESCRIPTION
New versions of Chrome return 0 for document.body.scrollHeight.  This change should fix Chrome while keeping compatibility with older browsers.